### PR TITLE
Update go toolchain to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,4 +91,4 @@ require (
 
 go 1.24.0
 
-toolchain go1.24.4
+toolchain go1.25.7


### PR DESCRIPTION
Protects tool from CVE in go standard library
CVE-2025-68121
