### PR TITLE
chore: golangcli-lint upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,96 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - errcheck
+    - goprintffuncname
+    - gosec
+    - ineffassign
+    - misspell
+    - nakedret
+    - rowserrcheck
+    - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - revive
+    - gocritic
+    - govet
+    - goconst
+  settings:
+    depguard:
+      rules:
+        Main:
+          list-mode: lax
+          deny:
+            - pkg: github.com/jenkins-x/jx/v2/pkg/log/
+              desc: "use jenkins-x/jx-logging instead"
+            - pkg: github.com/satori/go.uuid
+              desc: "use github.com/google/uuid instead"
+            - pkg: github.com/pborman/uuid
+              desc: "use github.com/google/uuid instead"
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: false
+    funlen:
+      lines: 200
+      statements: 150
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+        - importShadow
+        - unnamedResult
+    gocyclo:
+      min-complexity: 15
+    revive:
+      confidence: 0
+    mnd:
+      checks: [argument, case, condition, return]
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
+    lll:
+      line-length: 140
+    nolintlint:
+      allow-unused: false
+      require-explanation: false
+      require-specific: false
+
+formatters:
+  enable:
+    - goimports
+    - gofmt
+  settings:
+    gofmt:
+      simplify: true
+
+run:
+  timeout: 15m
+
+issues:
+  exclude-dirs:
+    - vendor

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,5 +1,6 @@
 //go:build !windows
 
+// Package app provides the entry point for non-Windows platforms.
 package app
 
 import (

--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -82,7 +82,7 @@ func loadLongDescription(cmd *cobra.Command, path ...string) error {
 			continue
 		}
 
-		content, err := os.ReadFile(fullpath)
+		content, err := os.ReadFile(fullpath) //nolint:gosec
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func parseArgs() (*options, error) {
 	return opts, err
 }
 
-func parseMDContent(mdString string) (description string, examples string) {
+func parseMDContent(mdString string) (description, examples string) {
 	parsedContent := strings.Split(mdString, "\n## ")
 	for _, s := range parsedContent {
 		if strings.Index(s, "Description") == 0 {

--- a/cmd/docs/man_docs.go
+++ b/cmd/docs/man_docs.go
@@ -67,11 +67,11 @@ func GenManTreeFromOpts(cmd *cobra.Command, opts GenManTreeOptions) error {
 	}
 	basename := strings.ReplaceAll(cmd.CommandPath(), " ", separator)
 	filename := filepath.Join(opts.Path, basename+"."+section)
-	f, err := os.Create(filename)
+	f, err := os.Create(filename) //nolint:gosec
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	headerCopy := *header
 	return GenMan(cmd, &headerCopy, f)
@@ -125,7 +125,7 @@ func fillHeader(header *GenManHeader, name string) error {
 
 func manPreamble(buf io.StringWriter, header *GenManHeader, cmd *cobra.Command, dashedName string) {
 	description := cmd.Long
-	if len(description) == 0 {
+	if description == "" {
 		description = cmd.Short
 	}
 
@@ -143,16 +143,16 @@ func manPreamble(buf io.StringWriter, header *GenManHeader, cmd *cobra.Command, 
 
 func manPrintFlags(buf io.StringWriter, flags *pflag.FlagSet) {
 	flags.VisitAll(func(flag *pflag.Flag) {
-		if len(flag.Deprecated) > 0 || flag.Hidden {
+		if flag.Deprecated != "" || flag.Hidden {
 			return
 		}
 		format := ""
-		if len(flag.Shorthand) > 0 && len(flag.ShorthandDeprecated) == 0 {
+		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
 			format = fmt.Sprintf("**-%s**, **--%s**", flag.Shorthand, flag.Name)
 		} else {
 			format = fmt.Sprintf("**--%s**", flag.Name)
 		}
-		if len(flag.NoOptDefVal) > 0 {
+		if flag.NoOptDefVal != "" {
 			format += "["
 		}
 		if flag.Value.Type() == "string" {
@@ -161,7 +161,7 @@ func manPrintFlags(buf io.StringWriter, flags *pflag.FlagSet) {
 		} else {
 			format += "=%s"
 		}
-		if len(flag.NoOptDefVal) > 0 {
+		if flag.NoOptDefVal != "" {
 			format += "]"
 		}
 		format += "\n\t%s\n\n"
@@ -195,9 +195,9 @@ func genMan(cmd *cobra.Command, header *GenManHeader) []byte {
 
 	manPreamble(buf, header, cmd, dashCommandName)
 	manPrintOptions(buf, cmd)
-	if len(cmd.Example) > 0 {
+	if cmd.Example != "" {
 		buf.WriteString("# EXAMPLE\n")
-		buf.WriteString(fmt.Sprintf("\n%s\n\n", cmd.Example))
+		fmt.Fprintf(buf, "\n%s\n\n", cmd.Example)
 	}
 	if hasSeeAlso(cmd) {
 		buf.WriteString("# SEE ALSO\n")

--- a/cmd/docs/md_docs.go
+++ b/cmd/docs/md_docs.go
@@ -55,7 +55,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 
 	short := cmd.Short
 	long := cmd.Long
-	if len(long) == 0 {
+	if long == "" {
 		long = short
 	}
 
@@ -63,21 +63,21 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	buf.WriteString(short + "\n\n")
 
 	if len(cmd.Aliases) > 0 {
-		buf.WriteString(fmt.Sprintf("***Aliases**: %s*\n\n", strings.Join(cmd.Aliases, ",")))
+		fmt.Fprintf(buf, "***Aliases**: %s*\n\n", strings.Join(cmd.Aliases, ","))
 	}
 
 	if cmd.Runnable() {
 		buf.WriteString("### Usage\n\n")
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.UseLine()))
+		fmt.Fprintf(buf, "```\n%s\n```\n\n", cmd.UseLine())
 	}
 
 	buf.WriteString("### Synopsis\n\n")
 
 	buf.WriteString(long + "\n\n")
 
-	if len(cmd.Example) > 0 {
+	if cmd.Example != "" {
 		buf.WriteString("### Examples\n\n")
-		buf.WriteString(fmt.Sprintf("%s\n\n", cmd.Example))
+		fmt.Fprintf(buf, "%s\n\n", cmd.Example)
 	}
 
 	if err := printOptions(buf, cmd); err != nil {
@@ -90,7 +90,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			pname := parent.CommandPath()
 			link := pname + ".md"
 			link = strings.ReplaceAll(link, " ", "_")
-			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short))
+			fmt.Fprintf(buf, "* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short)
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
 					cmd.DisableAutoGenTag = c.DisableAutoGenTag
@@ -108,7 +108,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			cname := name + " " + child.Name()
 			link := cname + ".md"
 			link = strings.ReplaceAll(link, " ", "_")
-			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short))
+			fmt.Fprintf(buf, "* [%s](%s)\t - %s\n", cname, linkHandler(link), child.Short)
 		}
 		buf.WriteString("\n")
 	}
@@ -127,7 +127,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 // help output will be in the file `cmd-sub-third.1`.
 func GenMarkdownTree(cmd *cobra.Command, dir string) error {
 	identity := func(s string) string { return s }
-	emptyStr := func(s string) string { return "" }
+	emptyStr := func(_ string) string { return "" }
 	return GenMarkdownTreeCustom(cmd, dir, emptyStr, identity)
 }
 
@@ -145,13 +145,13 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 
 	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
 	filename := filepath.Join(dir, basename)
-	f, err := os.Create(filename)
+	f, err := os.Create(filename) //nolint:gosec
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
-	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
+	if _, err := f.WriteString(filePrepender(filename)); err != nil {
 		return err
 	}
 	if err := GenMarkdownCustom(cmd, f, linkHandler); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for jx-scm.
 package main
 
 import (

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -7,34 +7,16 @@ then
   exit 0
 fi
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+linterVersion="$(golangci-lint --version | awk '{print $4}')"
 
-if ! [ -x "$(command -v golangci-lint)" ]; then
-	echo "Installing GolangCI-Lint"
-	${DIR}/install_golint.sh -b $GOPATH/bin v1.20.0
+expectedLinterVersion=2.12.2
+
+if [ "${linterVersion}" != "${expectedLinterVersion}" ]; then
+	echo "Install GolangCI-Lint version ${expectedLinterVersion}"
+  exit 1
 fi
 
 export GO111MODULE=on
 golangci-lint run \
-	--no-config \
-  --disable-all \
-  -E revive \
-  -E errcheck \
-	-E misspell \
-  -E unconvert \
-  -E gosec \
-  -E gofmt \
-  -E goimports \
-  -E govet \
-  -E unparam \
-  -E megacheck \
-  -E goconst \
-  -E ineffassign \
-  -E unparam \
-  -E gocritic \
-  -E typecheck \
-  --skip-dirs vendor \
-  --deadline 15m0s \
   --verbose \
   --build-tags build
-

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -1,3 +1,4 @@
+// Package close provides the close pull request command.
 package close
 
 import (
@@ -36,7 +37,7 @@ var (
 	_ = termcolor.ColorInfo
 )
 
-// LabelOptions the options for the command
+// Options the options for the command
 type Options struct {
 	scmclient.Options
 
@@ -62,12 +63,12 @@ func NewCmdClosePullRequest() (*cobra.Command, *Options) {
 		Short:   "closes a pull request",
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName, rootcmd.BinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},
 	}
-	o.Options.AddFlags(cmd)
+	o.AddFlags(cmd)
 
 	cmd.Flags().StringVarP(&o.Owner, "owner", "o", "", "the owner of the repository that contains pull requests to close. Either an organisation or username. For Azure, include the project: 'organization/project'")
 	cmd.Flags().StringVarP(&o.Name, "name", "r", "", "the name of the repository that contains pull requests to close")

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/jenkins-x-plugins/jx-scm/pkg/cmd/pr/close"
 )
 
-func TestClosePullRequestByNumber(t *testing.T) {
+func TestClosePullRequestByNumber(_ *testing.T) {
 	// Needs testing
 }
 
-func TestClosePullRequestByBefore(t *testing.T) {
+func TestClosePullRequestByBefore(_ *testing.T) {
 	// Needs testing
 }
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -1,3 +1,4 @@
+// Package create provides the create pull request command.
 package create
 
 import (
@@ -45,7 +46,7 @@ var (
 	_ = termcolor.ColorInfo
 )
 
-// LabelOptions the options for the command
+// Options the options for the command
 type Options struct {
 	scmclient.Options
 
@@ -71,12 +72,12 @@ func NewCmdCreatePullRequest() (*cobra.Command, *Options) {
 		Short:   "Creates a pull request",
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName, rootcmd.BinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},
 	}
-	o.Options.AddFlags(cmd)
+	o.AddFlags(cmd)
 
 	cmd.Flags().StringVarP(&o.Owner, "owner", "o", "", "the owner of the repository. Either an organisation or username. For Azure, include the project: 'organization/project'")
 	cmd.Flags().StringVarP(&o.Name, "name", "r", "", "the name of the repository")
@@ -147,7 +148,7 @@ func (o *Options) Run() error {
 	return nil
 }
 
-func updateNecessary(ctx context.Context, head string, base string, updateAllowed bool, scmClient *scm.Client, fullName string) (bool, int) {
+func updateNecessary(ctx context.Context, head, base string, updateAllowed bool, scmClient *scm.Client, fullName string) (bool, int) {
 	if !updateAllowed {
 		return false, 0
 	}
@@ -155,7 +156,8 @@ func updateNecessary(ctx context.Context, head string, base string, updateAllowe
 	return FindOpenPullRequestByBranches(ctx, head, base, scmClient, fullName)
 }
 
-func FindOpenPullRequestByBranches(ctx context.Context, head string, base string, scmClient *scm.Client, fullName string) (bool, int) {
+// FindOpenPullRequestByBranches finds an open PR matching the given head and base branches.
+func FindOpenPullRequestByBranches(ctx context.Context, head, base string, scmClient *scm.Client, fullName string) (bool, int) {
 	var openPullRequests []*scm.PullRequest
 	page := 1
 

--- a/pkg/cmd/pr/pull_request.go
+++ b/pkg/cmd/pr/pull_request.go
@@ -1,3 +1,4 @@
+// Package pr provides commands for working with pull requests.
 package pr
 
 import (
@@ -14,7 +15,7 @@ func NewCmdPullRequest() *cobra.Command {
 		Use:     "pull-request",
 		Short:   "Commands for working with pull-requests",
 		Aliases: []string{"pr"},
-		Run: func(command *cobra.Command, args []string) {
+		Run: func(command *cobra.Command, _ []string) {
 			err := command.Help()
 			if err != nil {
 				log.Logger().Error(err.Error())

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -1,3 +1,4 @@
+// Package release provides commands for working with releases.
 package release
 
 import (
@@ -13,7 +14,7 @@ func NewCmdRelease() *cobra.Command {
 		Use:     "release",
 		Short:   "Commands for working with releases",
 		Aliases: []string{"release"},
-		Run: func(command *cobra.Command, args []string) {
+		Run: func(command *cobra.Command, _ []string) {
 			err := command.Help()
 			if err != nil {
 				log.Logger().Error(err.Error())

--- a/pkg/cmd/release/update/update.go
+++ b/pkg/cmd/release/update/update.go
@@ -1,3 +1,4 @@
+// Package update provides the release update command.
 package update
 
 import (
@@ -31,7 +32,7 @@ var (
 	_ = termcolor.ColorInfo
 )
 
-// LabelOptions the options for the command
+// Options the options for the command
 type Options struct {
 	scmclient.Options
 
@@ -53,12 +54,12 @@ func NewCmdUpdateRelease() (*cobra.Command, *Options) {
 		Short:   "Updates a release",
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName, rootcmd.BinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},
 	}
-	o.Options.AddFlags(cmd)
+	o.AddFlags(cmd)
 
 	cmd.Flags().StringVarP(&o.Owner, "owner", "o", "", "the owner of the repository to update. Either an organisation or username.  For Azure, include the project: 'organization/project'")
 	cmd.Flags().StringVarP(&o.Name, "name", "r", "", "the name of the repository to update")
@@ -70,7 +71,7 @@ func NewCmdUpdateRelease() (*cobra.Command, *Options) {
 	return cmd, o
 }
 
-// Run transforms the YAML files
+// Validate validates the options and returns the ScmClient
 func (o *Options) Validate() (*scm.Client, error) {
 	scmClient, err := o.Options.Validate()
 	if err != nil {

--- a/pkg/cmd/repository/clone/clone.go
+++ b/pkg/cmd/repository/clone/clone.go
@@ -1,3 +1,4 @@
+// Package clone provides the repository clone command.
 package clone
 
 import (
@@ -29,7 +30,7 @@ var (
 	info = termcolor.ColorInfo
 )
 
-// LabelOptions the options for the command
+// Options the options for the command
 type Options struct {
 	options.BaseOptions
 
@@ -48,18 +49,18 @@ func NewCmdCloneRepository() (*cobra.Command, *Options) {
 		Short:   "Clones a git repository",
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			o.Args = args
 			err := o.Run()
 			helper.CheckErr(err)
 		},
 	}
 
-	o.BaseOptions.AddBaseFlags(cmd)
+	o.AddBaseFlags(cmd)
 	return cmd, o
 }
 
-// Run transforms the YAML files
+// Validate validates the options
 func (o *Options) Validate() error {
 	err := o.BaseOptions.Validate()
 	if err != nil {

--- a/pkg/cmd/repository/create/create.go
+++ b/pkg/cmd/repository/create/create.go
@@ -1,3 +1,4 @@
+// Package create provides the repository create command.
 package create
 
 import (
@@ -36,7 +37,7 @@ var (
 	info = termcolor.ColorInfo
 )
 
-// LabelOptions the options for the command
+// Options the options for the command
 type Options struct {
 	options.BaseOptions
 	scmclient.Options
@@ -62,7 +63,7 @@ func NewCmdCreateRepository() (*cobra.Command, *Options) {
 		Short:   "Creates a new git provider in a git server",
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName, rootcmd.BinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			o.Args = args
 			err := o.Run()
 			helper.CheckErr(err)
@@ -78,8 +79,8 @@ func NewCmdCreateRepository() (*cobra.Command, *Options) {
 	cmd.Flags().BoolVarP(&o.Private, "private", "", false, "if the repository should be private")
 	cmd.Flags().BoolVarP(&o.Confirm, "confirm", "", false, "confirms creating the repository")
 
-	o.Options.AddFlags(cmd)
-	o.BaseOptions.AddBaseFlags(cmd)
+	o.AddFlags(cmd)
+	o.AddBaseFlags(cmd)
 	return cmd, o
 }
 
@@ -191,8 +192,8 @@ func (o *Options) createTemplate(template string) error {
 		log.Logger().Infof("switching to the git clone URL %s", info(cloneURL))
 	}
 
-	username := o.Options.Username
-	remoteURL, err := stringhelpers.URLSetUserPassword(cloneURL, username, o.Options.Token)
+	username := o.Username
+	remoteURL, err := stringhelpers.URLSetUserPassword(cloneURL, username, o.Token)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create the remote git URL for %s and user %s", cloneURL, username)
 	}

--- a/pkg/cmd/repository/remove/remove.go
+++ b/pkg/cmd/repository/remove/remove.go
@@ -1,3 +1,4 @@
+// Package remove provides the repository remove command.
 package remove
 
 import (
@@ -40,7 +41,7 @@ var (
 	info = termcolor.ColorInfo
 )
 
-// LabelOptions the options for the command
+// Options the options for the command
 type Options struct {
 	scmhelpers.Factory
 
@@ -57,7 +58,7 @@ type Options struct {
 	CreatedBeforeTime *time.Time
 }
 
-// NewCmdCreateRepository creates a command object for the command
+// NewCmdRemoveRepository creates a command object for the command
 func NewCmdRemoveRepository() (*cobra.Command, *Options) {
 	o := &Options{}
 
@@ -67,12 +68,12 @@ func NewCmdRemoveRepository() (*cobra.Command, *Options) {
 		Aliases: []string{"delete", "rm"},
 		Long:    cmdLong,
 		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName, rootcmd.BinaryName, rootcmd.BinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},
 	}
-	o.Factory.AddFlags(cmd)
+	o.AddFlags(cmd)
 
 	cmd.Flags().StringVarP(&o.Owner, "owner", "o", "", "the owner of the repository to create. Either an organisation or username.  For Azure, include the project: 'organization/project'")
 	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "the name of the repository to create")
@@ -86,12 +87,12 @@ func NewCmdRemoveRepository() (*cobra.Command, *Options) {
 	return cmd, o
 }
 
-// Run transforms the YAML files
+// Validate validates the options and returns the ScmClient
 func (o *Options) Validate() (*scm.Client, error) {
-	if o.Factory.GitServerURL == "" {
-		o.Factory.GitServerURL = giturl.GitHubURL
+	if o.GitServerURL == "" {
+		o.GitServerURL = giturl.GitHubURL
 	}
-	scmClient, err := o.Factory.Create()
+	scmClient, err := o.Create()
 	if err != nil {
 		return scmClient, errors.Wrapf(err, "failed to create SCM client")
 	}

--- a/pkg/cmd/repository/repository.go
+++ b/pkg/cmd/repository/repository.go
@@ -1,3 +1,4 @@
+// Package repository provides commands for working with source repositories.
 package repository
 
 import (
@@ -15,7 +16,7 @@ func NewCmdRepository() *cobra.Command {
 		Use:     "repository",
 		Short:   "Commands for working with source repositories",
 		Aliases: []string{"repo", "repos", "repositories"},
-		Run: func(command *cobra.Command, args []string) {
+		Run: func(command *cobra.Command, _ []string) {
 			err := command.Help()
 			if err != nil {
 				log.Logger().Error(err.Error())

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,3 +1,4 @@
+// Package cmd provides the root command and subcommands for jx-scm.
 package cmd
 
 import (
@@ -20,7 +21,7 @@ func Main() *cobra.Command {
 			cobra.CommandDisplayNameAnnotation: rootcmd.TopLevelCommand,
 		},
 		Short: "GitOps utility commands",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			err := cmd.Help()
 			if err != nil {
 				log.Logger().Error(err.Error())

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,3 +1,4 @@
+// Package version provides the version command.
 package version
 
 import (
@@ -25,7 +26,7 @@ const (
 	TestVersion = "1.0.0-SNAPSHOT"
 )
 
-// ShowOptions the options for viewing running PRs
+// Options the options for viewing running PRs
 type Options struct {
 	Verbose bool
 }
@@ -37,7 +38,7 @@ func NewCmdVersion() (*cobra.Command, *Options) {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Displays the version of this command",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			err := o.Run()
 			helper.CheckErr(err)
 		},
@@ -52,6 +53,7 @@ func (o *Options) Run() error {
 	return nil
 }
 
+// GetVersion returns the binary version string.
 func GetVersion() string {
 	if Version != "" {
 		return Version

--- a/pkg/rootcmd/helpers.go
+++ b/pkg/rootcmd/helpers.go
@@ -1,3 +1,4 @@
+// Package rootcmd provides shared binary name and top-level command variables.
 package rootcmd
 
 import (

--- a/pkg/scmclient/options.go
+++ b/pkg/scmclient/options.go
@@ -1,3 +1,4 @@
+// Package scmclient provides common SCM client options and helpers.
 package scmclient
 
 import (
@@ -26,6 +27,7 @@ type Options struct {
 	GitCommandRunner cmdrunner.CommandRunner
 }
 
+// AddFlags adds common SCM flags to the given command.
 func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Kind, "kind", "k", "", "the kind of git server to use")
 	cmd.Flags().StringVarP(&o.Server, "server", "s", "", "the git server URL to use")


### PR DESCRIPTION
upgrade golangci-lint to v2.12.2.

Changes:

1. hack/linter.sh — bumped expectedLinterVersion to 2.12.2
2. .golangci.yml — rewrote the config in the v2 format (linter sections, settings structure, formatters, etc.)
3. Fixed all 52 lint issues introduced by the stricter v2 rules across the codebase:
  - errcheck (2): defer f.Close() → defer func() { _ = f.Close() }() in the docs generators
  - gosec G304 (3): added //nolint:gosec on intentional file-path operations
  - gocritic (17): len(x) == 0 → x == "", buf.WriteString(fmt.Sprintf(...)) → fmt.Fprintf(buf, ...), combined redundant named return types, etc.
  - revive (22): added missing package comments to ~10 packages, fixed exported symbol comment formats (// LabelOptions → // Options ...), renamed unused cmd/args/t/s parameters to _
  - staticcheck QF1008 (8): removed unnecessary embedded field qualifiers from selectors (e.g. o.Options.AddFlags(cmd) → o.AddFlags(cmd), o.Factory.GitServerURL → o.GitServerURL)